### PR TITLE
Fix Milvus cross-namespace resolution in OGX issues

### DIFF
--- a/lab_runner/defaults.py
+++ b/lab_runner/defaults.py
@@ -452,8 +452,9 @@ chart_path: charts/milvus
 """
 
 
-def gitops_ogx_config_yaml(env: str) -> str:
+def gitops_ogx_config_yaml(env: str, username: str) -> str:
     service = f"milvus-{env}"
+    milvus_ns = f"{username}-{env}"
     return f"""---
 chart_path: charts/llama-stack-operator-instance
 models:
@@ -463,6 +464,7 @@ rag:
   enabled: true
   milvus:
     service: "{service}"
+    namespace: "{milvus_ns}"
 """
 
 
@@ -605,8 +607,9 @@ chart_path: charts/nemo-guardrails-orchestrator
 """
 
 
-def gitops_ogx_guardrails_config_yaml(env: str) -> str:
+def gitops_ogx_guardrails_config_yaml(env: str, username: str) -> str:
     service = f"milvus-{env}"
+    milvus_ns = f"{username}-{env}"
     return f"""---
 chart_path: charts/llama-stack-operator-instance
 models:
@@ -616,6 +619,7 @@ rag:
   enabled: true
   milvus:
     service: "{service}"
+    namespace: "{milvus_ns}"
 guardrails:
   enabled: true
 """
@@ -697,8 +701,9 @@ LLAMA_STACK_MCP_VALUES = {
 }
 
 
-def gitops_ogx_mcp_config_yaml(env: str) -> str:
+def gitops_ogx_mcp_config_yaml(env: str, username: str) -> str:
     service = f"milvus-{env}"
+    milvus_ns = f"{username}-{env}"
     return f"""---
 chart_path: charts/llama-stack-operator-instance
 models:
@@ -708,6 +713,7 @@ rag:
   enabled: true
   milvus:
     service: "{service}"
+    namespace: "{milvus_ns}"
 guardrails:
   enabled: true
 mcp:
@@ -922,9 +928,11 @@ spec:
       storageUri: 'oci://quay.io/rh-aiservices-bu/tinyllama:1.0'
 """
 
-def llama_stack_onprem_values(namespace: str) -> dict:
+def llama_stack_onprem_values(namespace: str, username: str) -> dict:
+    milvus_ns = f"{username}-test"
     return {
         **LLAMA_STACK_RAG_VALUES,
+        "rag": {"enabled": True, "milvus": {"service": "milvus-test", "namespace": milvus_ns}},
         "models": [
             {"name": "llama32", "url": "http://llama-32-predictor.ai501.svc.cluster.local:8080/v1"},
             {"name": "tinyllama", "url": f"http://tinyllama-predictor.{namespace}.svc.cluster.local:8080/v1"},
@@ -953,9 +961,10 @@ LLAMA_STACK_FP8_VALUES = {
 }
 
 
-def gitops_ogx_fp8_config_yaml() -> str:
+def gitops_ogx_fp8_config_yaml(username: str) -> str:
     """OGX config with both llama32 and llama32-fp8 models."""
-    return """---
+    milvus_ns = f"{username}-test"
+    return f"""---
 chart_path: charts/llama-stack-operator-instance
 models:
   - name: "llama32"
@@ -966,6 +975,7 @@ rag:
   enabled: true
   milvus:
     service: "milvus-test"
+    namespace: "{milvus_ns}"
 guardrails:
   enabled: true
 mcp:

--- a/lab_runner/defaults.py
+++ b/lab_runner/defaults.py
@@ -446,6 +446,18 @@ LLAMA_STACK_RAG_VALUES = {
     ],
 }
 
+def milvus_externalname_manifest(service_name: str, target_namespace: str) -> str:
+    return f"""\
+apiVersion: v1
+kind: Service
+metadata:
+  name: {service_name}
+spec:
+  type: ExternalName
+  externalName: {service_name}.{target_namespace}.svc.cluster.local
+"""
+
+
 def milvus_config_yaml(env: str) -> str:
     return f"""---
 chart_path: charts/milvus
@@ -928,11 +940,9 @@ spec:
       storageUri: 'oci://quay.io/rh-aiservices-bu/tinyllama:1.0'
 """
 
-def llama_stack_onprem_values(namespace: str, username: str) -> dict:
-    milvus_ns = f"{username}-test"
+def llama_stack_onprem_values(namespace: str) -> dict:
     return {
         **LLAMA_STACK_RAG_VALUES,
-        "rag": {"enabled": True, "milvus": {"service": "milvus-test", "namespace": milvus_ns}},
         "models": [
             {"name": "llama32", "url": "http://llama-32-predictor.ai501.svc.cluster.local:8080/v1"},
             {"name": "tinyllama", "url": f"http://tinyllama-predictor.{namespace}.svc.cluster.local:8080/v1"},

--- a/lab_runner/modules/m05_rag.py
+++ b/lab_runner/modules/m05_rag.py
@@ -4,7 +4,7 @@ from lab_runner.config import Config
 from lab_runner import defaults
 from lab_runner.modules.base import Module
 from lab_runner.steps.base import Step
-from lab_runner.steps.kube_step import WaitForArgoCDAppsStep, WaitForReadyStep
+from lab_runner.steps.kube_step import ApplyManifestStep, WaitForArgoCDAppsStep, WaitForReadyStep
 from lab_runner.steps.git_step import CloneAndModifyStep
 from lab_runner.steps.webhook_step import ConfigureMinIOWebhookStep, UploadDocumentToMinIOStep
 from lab_runner.steps.verify_step import CheckPodRunningStep
@@ -32,23 +32,7 @@ class RAGModule(Module):
 
         steps: list[Step] = []
 
-        # 1. Install llama-stack (OGX) in userX-canopy
-        steps.append(HelmInstallStep(
-            release_name="llama-stack-operator-instance",
-            chart=defaults.CHART_LLAMA_STACK,
-            namespace=ns,
-            values={**defaults.LLAMA_STACK_RAG_VALUES, "rag": {"enabled": True, "milvus": {"service": "milvus-test", "namespace": config.test_namespace}}},
-            description="Install LlamaStack (OGX) in canopy namespace",
-        ))
-
-        # 1.5 Wait for llama-stack ready
-        steps.append(WaitForReadyStep(
-            label="app=llama-stack",
-            namespace=ns,
-            description="Wait for LlamaStack ready in canopy",
-        ))
-
-        # 2. Add Milvus configs for test and prod
+        # 1. Add Milvus configs for test and prod
         steps.append(CloneAndModifyStep(
             repo_url=config.gitops_repo_url,
             modifications={
@@ -67,6 +51,31 @@ class RAGModule(Module):
             namespace=toolings_ns,
             timeout=600,
             description="Wait for Milvus deployed in test and prod",
+        ))
+
+        # 3. Create ExternalName service so milvus-test resolves across namespaces
+        steps.append(ApplyManifestStep(
+            manifest=defaults.milvus_externalname_manifest("milvus-test", test_ns),
+            namespace=ns,
+            resource_type="service",
+            resource_name="milvus-test",
+            description="Create Milvus ExternalName service in canopy",
+        ))
+
+        # 4. Install llama-stack (OGX) in userX-canopy
+        steps.append(HelmInstallStep(
+            release_name="llama-stack-operator-instance",
+            chart=defaults.CHART_LLAMA_STACK,
+            namespace=ns,
+            values=defaults.LLAMA_STACK_RAG_VALUES,
+            description="Install LlamaStack (OGX) in canopy namespace",
+        ))
+
+        # 5. Wait for llama-stack ready
+        steps.append(WaitForReadyStep(
+            label="app=llama-stack",
+            namespace=ns,
+            description="Wait for LlamaStack ready in canopy",
         ))
 
         # 3. Add OGX (llama-stack-operator-instance) configs for test and prod

--- a/lab_runner/modules/m05_rag.py
+++ b/lab_runner/modules/m05_rag.py
@@ -37,13 +37,13 @@ class RAGModule(Module):
             release_name="llama-stack-operator-instance",
             chart=defaults.CHART_LLAMA_STACK,
             namespace=ns,
-            values=defaults.LLAMA_STACK_RAG_VALUES,
+            values={**defaults.LLAMA_STACK_RAG_VALUES, "rag": {"enabled": True, "milvus": {"service": "milvus-test", "namespace": config.test_namespace}}},
             description="Install LlamaStack (OGX) in canopy namespace",
         ))
 
         # 1.5 Wait for llama-stack ready
         steps.append(WaitForReadyStep(
-            label="app.kubernetes.io/name=llama-stack-operator-instance",
+            label="app=llama-stack",
             namespace=ns,
             description="Wait for LlamaStack ready in canopy",
         ))
@@ -73,8 +73,8 @@ class RAGModule(Module):
         steps.append(CloneAndModifyStep(
             repo_url=config.gitops_repo_url,
             modifications={
-                "canopy/test/ogx/config.yaml": defaults.gitops_ogx_config_yaml("test"),
-                "canopy/prod/ogx/config.yaml": defaults.gitops_ogx_config_yaml("prod"),
+                "canopy/test/ogx/config.yaml": defaults.gitops_ogx_config_yaml("test", config.username),
+                "canopy/prod/ogx/config.yaml": defaults.gitops_ogx_config_yaml("prod", config.username),
             },
             commit_message="Add Open GenAI Stack instances",
             verify_repo="genaiops-gitops",

--- a/lab_runner/modules/m07_guardrails.py
+++ b/lab_runner/modules/m07_guardrails.py
@@ -34,8 +34,8 @@ class GuardrailsModule(Module):
             modifications={
                 "canopy/test/nemo-guardrails-orchestrator/config.yaml": defaults.nemo_guardrails_config_yaml(),
                 "canopy/prod/nemo-guardrails-orchestrator/config.yaml": defaults.nemo_guardrails_config_yaml(),
-                "canopy/test/ogx/config.yaml": defaults.gitops_ogx_guardrails_config_yaml("test"),
-                "canopy/prod/ogx/config.yaml": defaults.gitops_ogx_guardrails_config_yaml("prod"),
+                "canopy/test/ogx/config.yaml": defaults.gitops_ogx_guardrails_config_yaml("test", config.username),
+                "canopy/prod/ogx/config.yaml": defaults.gitops_ogx_guardrails_config_yaml("prod", config.username),
                 "canopy/test/backend/config.yaml": defaults.gitops_test_backend_guardrails_config_yaml(
                     config.username, config.cluster_domain
                 ),

--- a/lab_runner/modules/m08_agents.py
+++ b/lab_runner/modules/m08_agents.py
@@ -42,7 +42,7 @@ class AgentsModule(Module):
         steps.append(CloneAndModifyStep(
             repo_url=config.gitops_repo_url,
             modifications={
-                "canopy/test/ogx/config.yaml": defaults.gitops_ogx_mcp_config_yaml("test"),
+                "canopy/test/ogx/config.yaml": defaults.gitops_ogx_mcp_config_yaml("test", config.username),
                 "canopy/test/calendar-mcp/config.yaml": defaults.calendar_mcp_config_yaml(),
                 "canopy/test/backend/config.yaml": defaults.gitops_test_backend_agents_config_yaml(
                     config.username, config.cluster_domain

--- a/lab_runner/modules/m09_onprem.py
+++ b/lab_runner/modules/m09_onprem.py
@@ -48,7 +48,7 @@ class OnPremModule(Module):
             release_name="llama-stack-operator-instance",
             chart=defaults.CHART_LLAMA_STACK,
             namespace=ns,
-            values=defaults.llama_stack_onprem_values(ns, config.username),
+            values=defaults.llama_stack_onprem_values(ns),
             description="Upgrade LlamaStack (add TinyLlama model)",
         ))
 

--- a/lab_runner/modules/m09_onprem.py
+++ b/lab_runner/modules/m09_onprem.py
@@ -48,7 +48,7 @@ class OnPremModule(Module):
             release_name="llama-stack-operator-instance",
             chart=defaults.CHART_LLAMA_STACK,
             namespace=ns,
-            values=defaults.llama_stack_onprem_values(ns),
+            values=defaults.llama_stack_onprem_values(ns, config.username),
             description="Upgrade LlamaStack (add TinyLlama model)",
         ))
 

--- a/lab_runner/modules/m10_model_optimization.py
+++ b/lab_runner/modules/m10_model_optimization.py
@@ -30,7 +30,7 @@ class ModelOptimizationModule(Module):
         steps.append(CloneAndModifyStep(
             repo_url=config.gitops_repo_url,
             modifications={
-                "canopy/test/ogx/config.yaml": defaults.gitops_ogx_fp8_config_yaml(),
+                "canopy/test/ogx/config.yaml": defaults.gitops_ogx_fp8_config_yaml(config.username),
                 "canopy/test/backend/config.yaml": defaults.gitops_test_backend_fp8_config_yaml(
                     config.username, config.cluster_domain
                 ),


### PR DESCRIPTION
## Summary

- Add `milvus.namespace` field to all OGX config generators in `defaults.py` so the downstream Helm chart resolves Milvus in the correct namespace
- Update all module callers (m05, m07, m08, m09, m10) to pass `username` for namespace construction
- Override `LLAMA_STACK_RAG_VALUES` in `m05_rag.py` HelmInstallStep to include the namespace

## Problem

When llama-stack (OGX) is deployed into `{user}-canopy` via Helm, the Milvus URI resolves to `milvus-test.{user}-canopy.svc.cluster.local` because the chart defaults to `.Release.Namespace`. But Milvus runs in `{user}-test`, so the pod crash-loops with startup probe failures unable to connect.

Introduced by PR #5 which added a direct `HelmInstallStep` into the canopy namespace.

## Test plan

- [ ] Deploy lab-runner with the fix and run Module 5 (RAG) for a user
- [ ] Verify the generated OGX configmap contains `namespace: "{user}-test"` in the milvus section
- [ ] Confirm llama-stack pod in `{user}-canopy` connects to `milvus-test.{user}-test.svc.cluster.local`
- [ ] Verify Modules 7, 8, 9, 10 also generate correct milvus namespace in their configs

Fixes #6