### PR TITLE
fix(rag): remove invalid namespace property from OGX gitops config

### DIFF
--- a/lab_runner/defaults.py
+++ b/lab_runner/defaults.py
@@ -466,7 +466,6 @@ chart_path: charts/milvus
 
 def gitops_ogx_config_yaml(env: str, username: str) -> str:
     service = f"milvus-{env}"
-    milvus_ns = f"{username}-{env}"
     return f"""---
 chart_path: charts/llama-stack-operator-instance
 models:
@@ -476,7 +475,6 @@ rag:
   enabled: true
   milvus:
     service: "{service}"
-    namespace: "{milvus_ns}"
 """
 
 


### PR DESCRIPTION
## Summary

- Removes the `namespace` field from the generated `rag.milvus` config in `gitops_ogx_config_yaml()`
- The `llama-stack-operator-instance` chart schema has `additionalProperties: false` on `rag.milvus`, which only allows the `service` property
- This caused ArgoCD apps `ogx-test`/`ogx-prod` to fail with: `additional properties 'namespace' not allowed`
- The chart template already uses `.Release.Namespace` to build the Milvus URI, making the explicit namespace redundant

## Impact

Without this fix, LlamaStack is never deployed in test/prod namespaces. This blocks:
- KFP document-intelligence-rag-pipeline (`vector_database_component` cannot connect)
- KFP canopy-eval-mlflow (`run_all_mlflow_tests` hangs waiting for backend which depends on LlamaStack)

## Test plan

- [x] Verified on cluster: after removing `namespace`, ArgoCD synced `ogx-test`/`ogx-prod` successfully
- [x] LlamaStack pods running in both `user1-test` and `user1-prod`
- [x] Full end-to-end pipeline (doc-ingestion → evals → raise-pr) completed in ~4 minutes vs hanging indefinitely before

Made with [Cursor](https://cursor.com)