### PR TITLE
[BUG] Lab runner adds namespace key to milvus not in helm chart spec

### DIFF
--- a/lab_runner/defaults.py
+++ b/lab_runner/defaults.py
@@ -476,7 +476,6 @@ rag:
   enabled: true
   milvus:
     service: "{service}"
-    namespace: "{milvus_ns}"
 """
 
 
@@ -631,7 +630,6 @@ rag:
   enabled: true
   milvus:
     service: "{service}"
-    namespace: "{milvus_ns}"
 guardrails:
   enabled: true
 """
@@ -725,7 +723,6 @@ rag:
   enabled: true
   milvus:
     service: "{service}"
-    namespace: "{milvus_ns}"
 guardrails:
   enabled: true
 mcp:
@@ -985,7 +982,6 @@ rag:
   enabled: true
   milvus:
     service: "milvus-test"
-    namespace: "{milvus_ns}"
 guardrails:
   enabled: true
 mcp:


### PR DESCRIPTION
[charts/llama-stack-operator-instance/values.schema.json](https://github.com/rhoai-genaiops/genaiops-helmcharts/blob/71c725a478f306f8899a882463409eecadd65b3f/charts/llama-stack-operator-instance/values.schema.json) does not contain a namespace parameter under milvus so argo breaks rendering the chart when the runner has been executed.